### PR TITLE
Adding missing '/' to PATH

### DIFF
--- a/econtextapi/classify/html.py
+++ b/econtextapi/classify/html.py
@@ -3,7 +3,7 @@ from econtextapi.classify.classify import Classify
 
 class Html(Classify):
     
-    PATH = "html"
+    PATH = "/html"
     
     def __init__(self, client, classify_data=None, *args, **kwargs):
         super(Html, self).__init__(client, 'html', classify_data)


### PR DESCRIPTION
Classify html path is PATH = 'html'.  

Response 404: Invalid resource entity specified (/classifyhtml).


Should be '/html'. 